### PR TITLE
added current control

### DIFF
--- a/Adafruit_AW9523.cpp
+++ b/Adafruit_AW9523.cpp
@@ -299,7 +299,7 @@ bool Adafruit_AW9523::openDrainPort0(bool od) {
  * 01：0~(IMAX×3/4)
  * 10：0~(IMAX×2/4)
  * 11：0~(IMAX×1/4)
- * 
+ *
  *    @brief  Sets reduction of LED current from 1/4 Imax to Imax (0 = Imax,
  * 1 = 3/4 Imax, 2 = 1/2 Imax, 3 = 1/4 Imax). Imax = 37 mA
  *    @param  quarters_to_reduce: 0-3, how much to reduce the LED current

--- a/Adafruit_AW9523.cpp
+++ b/Adafruit_AW9523.cpp
@@ -300,12 +300,13 @@ bool Adafruit_AW9523::openDrainPort0(bool od) {
  * 10：0~(IMAX×2/4)
  * 11：0~(IMAX×1/4)
  * 
- *    @brief  Sets reduction of LED current from 1/4 Imax to Imax (0 = Imax, 1 = 3/4 Imax ... 3 = 1/4 Imax). Imax = 37 mA
+ *    @brief  Sets reduction of LED current from 1/4 Imax to Imax (0 = Imax, 
+ * 1 = 3/4 Imax, 2 = 1/2 Imax, 3 = 1/4 Imax). Imax = 37 mA
  *    @param  quarters_to_reduce: 0-3, how much to reduce the LED current
- *    @return True I2C write command was acknowledged
+ *    @return true if I2C write command was acknowledged
  * 
  */
-bool Adafruit_AW9523::configureLEDCurrent(uint8_t quarters_to_reduce) { 
+bool Adafruit_AW9523::configureLEDCurrent(uint8_t quarters_to_reduce) {
 
   Adafruit_I2CRegister gcrreg =
       Adafruit_I2CRegister(i2c_dev, AW9523_REG_GCR, 1);

--- a/Adafruit_AW9523.cpp
+++ b/Adafruit_AW9523.cpp
@@ -314,6 +314,4 @@ bool Adafruit_AW9523::configureLEDCurrent(uint8_t quarters_to_reduce) {
       Adafruit_I2CRegisterBits(&gcrreg, 2, 0); // # bits, bit_shift
 
   return ISEL.write(quarters_to_reduce);
-
 }
-

--- a/Adafruit_AW9523.cpp
+++ b/Adafruit_AW9523.cpp
@@ -292,3 +292,28 @@ bool Adafruit_AW9523::openDrainPort0(bool od) {
 
   return opendrain.write(!od);
 }
+
+/*!
+ * From the data sheet: 256 step dimming range select
+ * 00：0~IMAX
+ * 01：0~(IMAX×3/4)
+ * 10：0~(IMAX×2/4)
+ * 11：0~(IMAX×1/4)
+ * 
+ *    @brief  Sets reduction of LED current from 1/4 Imax to Imax (0 = Imax, 1 = 3/4 Imax ... 3 = 1/4 Imax). Imax = 37 mA
+ *    @param  quarters_to_reduce: 0-3, how much to reduce the LED current
+ *    @return True I2C write command was acknowledged
+ * 
+ */
+bool Adafruit_AW9523::configureLEDCurrent(uint8_t quarters_to_reduce) { 
+
+  Adafruit_I2CRegister gcrreg =
+      Adafruit_I2CRegister(i2c_dev, AW9523_REG_GCR, 1);
+
+  Adafruit_I2CRegisterBits ISEL =
+      Adafruit_I2CRegisterBits(&gcrreg, 2, 0); // # bits, bit_shift
+
+  return ISEL.write(quarters_to_reduce);
+
+}
+

--- a/Adafruit_AW9523.cpp
+++ b/Adafruit_AW9523.cpp
@@ -300,11 +300,11 @@ bool Adafruit_AW9523::openDrainPort0(bool od) {
  * 10：0~(IMAX×2/4)
  * 11：0~(IMAX×1/4)
  * 
- *    @brief  Sets reduction of LED current from 1/4 Imax to Imax (0 = Imax, 
+ *    @brief  Sets reduction of LED current from 1/4 Imax to Imax (0 = Imax,
  * 1 = 3/4 Imax, 2 = 1/2 Imax, 3 = 1/4 Imax). Imax = 37 mA
  *    @param  quarters_to_reduce: 0-3, how much to reduce the LED current
  *    @return true if I2C write command was acknowledged
- * 
+ *
  */
 bool Adafruit_AW9523::configureLEDCurrent(uint8_t quarters_to_reduce) {
 

--- a/Adafruit_AW9523.h
+++ b/Adafruit_AW9523.h
@@ -53,6 +53,7 @@ public:
   bool configureDirection(uint16_t pins);
   bool configureLEDMode(uint16_t pins);
   bool interruptEnableGPIO(uint16_t pins);
+  bool configureLEDCurrent(uint8_t quarters_to_reduce);
 
   // Individual pin control
   void pinMode(uint8_t pin, uint8_t mode);

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This is a library for the AW9523 GPIO Expander and LED Driver
 
-Forked from the Adafruit version by Keith Rohrer to add support for reducing the LED current.
-
 Designed specifically to work with the AW9523 breakout in the Adafruit shop:
 
 - https://www.adafruit.com/products/4886

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
 Written by Limor Fried/Ladyada for Adafruit Industries.  
-Forked from the Adafruit version by Keith Rohrer to add support for reducing the LED current.
+Support for the LED current control register added by Keith Rohrer.
 BSD license, all text above must be included in any redistribution.
 
 ## Installing this Library

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a library for the AW9523 GPIO Expander and LED Driver
 
+Forked from the Adafruit version by Keith Rohrer to add support for reducing the LED current.
+
 Designed specifically to work with the AW9523 breakout in the Adafruit shop:
 
 - https://www.adafruit.com/products/4886
@@ -12,6 +14,7 @@ please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
 Written by Limor Fried/Ladyada for Adafruit Industries.  
+Forked from the Adafruit version by Keith Rohrer to add support for reducing the LED current.
 BSD license, all text above must be included in any redistribution.
 
 ## Installing this Library

--- a/examples/constcurrent_demo/constcurrent_demo.ino
+++ b/examples/constcurrent_demo/constcurrent_demo.ino
@@ -17,6 +17,7 @@ void setup() {
 
   Serial.println("AW9523 found!");
   aw.pinMode(LedPin, AW9523_LED_MODE); // set to constant current drive!
+  aw.configureLEDCurrent(2); // half of 37 mA, since I have 20 mA LEDs
 }
 
 


### PR DESCRIPTION
I added one method to set the current control register.  Imax can be configured in the GCR register's 2 lsb.

I updated the LED constant current example to set Imax to 18.5 mA instead of 37.

I tested the change with LEDs, but I didn't test with out of range values (e.g. -1 or 4), I assume the update is already masked to just the specified bits by the object I copied from the other example of modifying the GCR register. 


