### PR TITLE
Update logic for computing dimming control register

### DIFF
--- a/Adafruit_AW9523.cpp
+++ b/Adafruit_AW9523.cpp
@@ -189,11 +189,9 @@ void Adafruit_AW9523::analogWrite(uint8_t pin, uint8_t val) {
   // See Table 13. 256 step dimming control register
   if (pin <= 7) {
     reg = 0x24 + pin;
-  }
-  if ((pin >= 8) && (pin <= 11)) {
+  } else if ((pin >= 8) && (pin <= 11)) {
     reg = 0x20 + pin - 8;
-  }
-  if ((pin >= 12) && (pin <= 15)) {
+  } else if ((pin >= 12) && (pin <= 15)) {
     reg = 0x2C + pin - 12;
   } else {
     return; // failed


### PR DESCRIPTION
For #8.

With existing logic, the final `else` clause is triggering for all pins not satisfying `((pin >= 12) && (pin <= 15))`. This masks the settings done in the conditionals prior and makes the lower pins (<12) inaccessible.

Tested using QT PY M0 and `constcurrent_demo.ino` example on pin 0.
Before - LED does not change brightness
After - LED brightness changes.